### PR TITLE
Infinite loop prevents tests from being ran inside a docker container

### DIFF
--- a/cmd/net.go
+++ b/cmd/net.go
@@ -86,20 +86,18 @@ func getHostIP4(host string) (ipList set.StringSet, err error) {
 		startTime := time.Now()
 		// wait for hosts to resolve in exponentialbackoff manner
 		for _ = range newRetryTimerSimple(doneCh) {
-			// Retry infinitely on Kubernetes and Docker swarm.
-			// This is needed as the remote hosts are sometime
-			// not available immediately.
 			if ips, err = net.LookupIP(host); err == nil {
 				break
 			}
 			// time elapsed
 			timeElapsed := time.Since(startTime)
 			// log error only if more than 1s elapsed
-			if timeElapsed > time.Second {
+			if timeElapsed > defaultRetryCap {
 				// log the message to console about the host not being
 				// resolveable.
 				errorIf(err, "Unable to resolve host %s (%s)", host,
 					humanize.RelTime(startTime, startTime.Add(timeElapsed), "elapsed", ""))
+				break
 			}
 		}
 	}


### PR DESCRIPTION
Tests `TestNewEndpoint`and `TestGetHostIP` freeze inside a infinite loop in `getHostIP4()` when ran inside a docker container.

This pull request adds a timeout to prevent this issue.