### PR TITLE
TestPutObjectLongName fails when ran in docker container 

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -1253,7 +1253,7 @@ func (s *TestSuiteCommon) TestPutObjectLongName(c *C) {
 	// Content for the object to be uploaded.
 	buffer := bytes.NewReader([]byte("hello world"))
 	// make long object name.
-	longObjName := fmt.Sprintf("%0255d/%0255d/%0255d", 1, 1, 1)
+	longObjName := fmt.Sprintf("%0242d/%0242d/%0242d", 1, 1, 1)
 	// create new HTTP request to insert the object.
 	request, err = newTestSignedRequest("PUT", getPutObjectURL(s.endPoint, bucketName, longObjName),
 		int64(buffer.Len()), buffer, s.accessKey, s.secretKey, s.signer)


### PR DESCRIPTION
Currently the `TestPutObjectLongName` will fail when ran in a docker container due to the file name length in [aufs](http://aufs.sourceforge.net/aufs3/man.html) which is being used by docker.

> Since aufs has several filename prefixes reserved, the maximum filename length is shorter than ordinary 255. Actually 242 (defined as ${AUFS_MAX_NAMELEN})

In order to address the issue the length is lowered to 242 in the test since running the tests inside a docker container is relevant for CI purposes.